### PR TITLE
version info ... not 50% DRYer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "colors"        : ">= 0.3.0",
     "coffee-resque" : ">= 0.1.4",
     "redisfs"       : ">= 1.0.0",
-    "async"         : ">= 0.1.15"
+    "async"         : ">= 0.1.15",
+    "pkginfo"       : ">= 0.2.3"
   },
   "devDependencies": {
     "vows"          : ">= 0.6.1",

--- a/src/mimeograph.coffee
+++ b/src/mimeograph.coffee
@@ -1,10 +1,3 @@
-mimeograph         = exports
-mimeograph.version = '1.1.0'
-# although pdf beads works with a variety of image types
-# it will only process images with certain extension - regardless
-# of the actual image type.  this happens to be one that pdfbeads
-# plays nicely with
-mimeograph.imageExtension = 'png'
 #
 # Dependencies
 #
@@ -15,6 +8,15 @@ resque         = require 'coffee-resque'
 {_, log, puts} = require './utils'
 async          = require 'async'
 path           = require 'path'
+pkginfo        = require('pkginfo')(module)
+
+mimeograph         = exports
+mimeograph.version = module.exports.version
+# although pdf beads works with a variety of image types
+# it will only process images with certain extension - regardless
+# of the actual image type.  this happens to be one that pdfbeads
+# plays nicely with
+mimeograph.imageExtension = 'png'
 
 #
 # export to global scope.  not ideal.


### PR DESCRIPTION
now reading version # from the package.json file - using a node module (pkginfo) to read the data
