### PR TITLE
track any stderr output from spawned child processes

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -20,6 +20,7 @@ stringify = (obj) -> if _.isString obj then obj else inspect obj
 # _ expandos
 #
 exports._ = _
+exports._.stringify     = stringify
 exports._.isObject      = (val) -> '[object Object]' is toString.apply val
 exports._.isEmptyObject = (val) -> _.isObject(val) and _.isEmpty(val)
 exports._.now           = -> new Date().toISOString()


### PR DESCRIPTION
added a new method to base Job class @spawn.  this method will track any stderr
output generated by the child process.  if the process returns an error code, it
will output the stderr output to the mimelog.  this makes error conditions a
little easier to resolve but looking at the logs.
