### PR TITLE
Track errors between jobs

### DIFF
--- a/src/mimeograph.coffee
+++ b/src/mimeograph.coffee
@@ -86,7 +86,8 @@ class Job
       log.debug "#{data}" for data in @outData if @outData?
       # handle error - have to check code & errorData because pdfbeads output
       # what appears to be non-error info to stderr.
-      if code
+      # code can be null if process exits abnormally
+      unless code == 0
         log.err "failure running #{commandInfo}"
         log.err "#{error}" for error in @errorData if @errorData?
       #pass control back to original callback
@@ -106,7 +107,7 @@ class Extractor extends Job
       @extract()
 
   extract: ->
-    proc = @spawn 'pdftotext', args:[@key], (code) =>
+    @spawn 'pdftotext', args:[@key], (code) =>
       return @fail "pdftotext exit(#{code})" if code
       @fetchText()
 
@@ -143,7 +144,7 @@ class Splitter  extends Job
       @split()
 
   split: ->
-    proc = @spawn 'pdftk', args: @args, (code) =>
+    @spawn 'pdftk', args: @args, (code) =>
       return @fail "pdftk exit(#{code})" if code
       @fetchPages()
 
@@ -195,7 +196,7 @@ class Converter extends Job
       callback null
 
   convert: (callback) =>
-    proc = @spawn 'convert', args: @args, (code) =>
+    @spawn 'convert', args: @args, (code) =>
       return callback "convert exit(#{code})" if code
       callback null
 
@@ -246,7 +247,7 @@ class Recognizer extends Job
       # need to be cognisant of this shortcircuit
       # bypass OCR is the job has already failed
       if status isnt 'fail'
-        proc = @spawn 'tesseract', args:@args, (code) =>
+        @spawn 'tesseract', args:@args, (code) =>
           return @fail "tesseract exit(#{code})" if code
           @fetchText()
       else
@@ -254,8 +255,8 @@ class Recognizer extends Job
         @complete()
 
   fetchText: ->
-    fs.readFile @file, 'utf8', (err, text) =>
-      return @fail err if err?
+    path.exists @file, (exists) =>
+      return @fail "Tesseract failed to create file #{@file}" unless exists
       fs.unlink @key
       @complete hocr: @file
 
@@ -316,7 +317,7 @@ class PageGenerator extends Job
       "#{IMAGE_DENSITY}"
       tempImage
     ]
-    proc = @spawn "convert", args:args, (code) =>
+    @spawn "convert", args:args, (code) =>
       return callback "convert exit(#{code})" if code
       callback null, tempImage
 
@@ -343,11 +344,15 @@ class PageGenerator extends Job
     # -include mimeo_pdfbeads as a executable in this package, which would
     #expose this ugliness to the user
     # -having to ensure that mimeo_pdfbeads has executable permission
-    proc = @spawn "ruby", args: args, options: {cwd: path.dirname(@image)}, (code) =>
+    @spawn "ruby", args: args, options: {cwd: path.dirname(@image)}, (code) =>
       return @fail "pdfbeads exit(#{code})" if code
-      fs.unlink file for file in [@image, @hocr]
-      # not returning contents of @page - just the file path
-      @complete page: @page
+      # I believe there are cases when the process returns a
+      # code of zero but failed to created the searchable page
+      path.exists @path, (exists) =>
+        return @fail "pdfbeads failed to create searchable PDF page #{@path}" unless exists
+        # not returning contents of @page - just the file path
+        fs.unlink file for file in [@image, @hocr]
+        @complete page: @page
 
 #
 # Layer the original PDF on top of the searchable PDF
@@ -386,10 +391,12 @@ class PdfLayer extends Job
 
   layer: (err) =>
     return @fail err if err?
-    proc = @spawn "pdftk", args: @args, (code) =>
+    @spawn "pdftk", args: @args, (code) =>
       return @fail "pdftk exit(#{code})" if code
-      fs.unlink file for file in [@backgroundPage, @foregroundPage]
-      @complete page: @layeredPage, pageNumber: _.pageNumber @layeredPage
+      path.exists @layeredPage, (exists) =>
+        return @fail "pdftk failed to create layered PDF #{@path}" unless exists
+        fs.unlink file for file in [@backgroundPage, @foregroundPage]
+        @complete page: @layeredPage, pageNumber: _.pageNumber @layeredPage
 
 #
 # Generate the searchable PDF by combining all of the individual
@@ -412,10 +419,12 @@ class PdfStitcher extends Job
       @stitch results
 
   stitch: (pages) ->
-    proc = @spawn 'pdftk', args: pages.concat(@args), options: {cwd: path.dirname(@page)}, (code) =>
+    @spawn 'pdftk', args: pages.concat(@args), options: {cwd: path.dirname(@page)}, (code) =>
       return @fail "pdftk exit(#{code})" if code
-      @cleanup pages
-      @complete page: @page
+      path.exists @page, (exists) =>
+        return @fail "pdftk failed to create merged PDF #{@path}" unless exists
+        @cleanup pages
+        @complete page: @page
 
   fetchPage: (pageKey, callback) ->
     redis2file pageKey, file: pageKey, callback
@@ -513,6 +522,9 @@ class Mimeograph
   # Orchestrates the job steps.
   #
   success: (worker, queue, job, result) =>
+    log.debug "success called"
+    log.debug job
+    log.debug result
     switch job.class
       when 'extract'     then @split result
       when 'split'       then @convert result
@@ -704,6 +716,10 @@ class Mimeograph
     options = key: file
     options.encoding = encoding.shift() unless _.isEmpty encoding
     file2redis file, options, (err) =>
+      # TODO a failure here will cause the next job to not be
+      # issued.  This will likely result in "zombie" jobs
+      # that never complete.  This will occur anytime
+      # a @capture is called
       return @capture err, {jobId: jobId, job: job} if err?
       @enqueue job, file, jobId
 

--- a/src/mimeograph.coffee
+++ b/src/mimeograph.coffee
@@ -346,8 +346,6 @@ class PageGenerator extends Job
     # -having to ensure that mimeo_pdfbeads has executable permission
     @spawn "ruby", args: args, options: {cwd: path.dirname(@image)}, (code) =>
       return @fail "pdfbeads exit(#{code})" if code
-      # I believe there are cases when the process returns a
-      # code of zero but failed to created the searchable page
       path.exists @page, (exists) =>
         return @fail "pdfbeads failed to create searchable PDF page #{@path}" unless exists
         # not returning contents of @page - just the file path

--- a/test/_testutils.coffee
+++ b/test/_testutils.coffee
@@ -24,6 +24,7 @@ switches = [
   ['-v', '--version', "Shows version."]
   ['-l', '--listen', 'Listen for mimegraph job completion messages.']
   ['-p', '--process [file]', 'Kicks of the processing of a new file.']
+  ['-i', '--processId [id]', 'Explicit id used for processing a file.']
   ['-c', '--cleanup', 'Delete all keys from redis']
   ['-r', '--redis [hostcolonport]', 'host:port for redis. can be specified as:
  <host>:<port>, <host> or :<port>. In left unspecified the default host and port
@@ -108,9 +109,8 @@ class Listener
     @client.quit()
 
 class KickStart
-  @kickStart: (sourceFile, redisConfig) ->
+  @kickStart: (sourceFile, redisConfig, jobId = new Date().getTime()) ->
     log "file to process: #{sourceFile}"
-    jobId = new Date().getTime()
     tmpTargetFile = "/tmp/#{jobId}"
 
     stats = fs.lstatSync sourceFile
@@ -162,4 +162,4 @@ testutils.run = ->
     CleanupRedis.cleanup(new RedisConfig(options.redis))
 
   if options.process
-    KickStart.kickStart options.process, new RedisConfig(options.redis)
+    KickStart.kickStart options.process, new RedisConfig(options.redis), options.processId


### PR DESCRIPTION
The original intent was to perform the work outlined in issue #39 "errors that occur "between" jobs result in lost jobs".  However, I realized that all of the errors i saw in production were slipping through because the check Job.spawn used to determine if the child process had an error was incorrect.  The check was "if code", and would trip error handling logic if code was > 0.  Unfortunately, nodejs states that the code will be null if the process doesn't terminate normally.  In these cases, Job.spawn thought the job was successful and the job class passed the location of a file thought to have been generated by the child process back to resque.  When mimeo then tried to store the non-existent file into redis ... pow!  in order to prevent these i corrected the error check in Job.spawn and introduced explicit path.exists calls to verify the generated file exists.

i also update Mimeograph.createJob to clean up any existing hset that corresponds to the key that the job will use.  this could result in the client never being notified of the jobs completion.  this key "clash" could occur when a job is rerun after mimeo stalls out or the client is disconnected.
